### PR TITLE
修复 toc_b 样式的渲染错误

### DIFF
--- a/themes/am_template.scss
+++ b/themes/am_template.scss
@@ -591,7 +591,7 @@ section.toc_b>ul,section.toc_b>ol {
   justify-content: center;
   width: 63%;
   left: 30%;
-  position: absolute;
+  position: relative;
   line-height: 200%;
 } 
 


### PR DESCRIPTION
Fix #48 

- 将 `position: absolute` 改为 `position: relative`